### PR TITLE
Access Pokemon's Previous `Move`

### DIFF
--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -34,6 +34,7 @@ class Pokemon:
         "_possible_abilities",
         "_preparing_move",
         "_preparing_target",
+        "_previous_move",
         "_protect_counter",
         "_shiny",
         "_revealed",
@@ -75,6 +76,7 @@ class Pokemon:
         self._max_hp: Optional[int] = 0
         self._moves: Dict[str, Move] = {}
         self._shiny: Optional[bool] = False
+        self._previous_move : Optional[Move] = None
 
         # Battle related attributes
 
@@ -238,6 +240,7 @@ class Pokemon:
         self._preparing_move = None
         self._preparing_target = None
         move = self._add_move(move_id, use=use)
+        self._previous_move = move
 
         if move and move.is_protect_counter and not failed:
             self._protect_counter += 1
@@ -272,6 +275,10 @@ class Pokemon:
 
         self._preparing_move = move
         self._preparing_target = target
+
+    @property
+    def previous_move(self) -> Optional[Move]:
+        return self._previous_move
 
     def primal(self):
         species_id_str = to_id_str(self._species)


### PR DESCRIPTION
in a `Player.choose_move` we should be able to use `battle.opponent_active_pokemon.previous_move` 

for heuristic logic we probably want to ignore previous moves from the last time the pokemon was switched in, which would be

```python
opp = battle.opponent_active_pokemon
prev_move = opp.previous_move if not opp.first_turn else None
```

In policy networks the true outcome of the previous turn should usually be pretty easy to infer from health, status, active opponent, and the opponent's previous move. I've been relying on PP counting to do this.