### PR TITLE
first_turn fix?

### DIFF
--- a/src/poke_env/environment/pokemon.py
+++ b/src/poke_env/environment/pokemon.py
@@ -241,6 +241,7 @@ class Pokemon:
         self._preparing_target = None
         move = self._add_move(move_id, use=use)
         self._previous_move = move
+        self._first_turn = False
 
         if move and move.is_protect_counter and not failed:
             self._protect_counter += 1


### PR DESCRIPTION
`Pokemon.first_turn` appears to be broken (?), set to True on switch_in and only set to False on switch_out???

Single Battles between two heuristic Players:

```
RandomBaseline 1 is choosing move in battle battle-gen1ou-249916 - first_turn? = True - opponent_first_turn? = True

Gen1Trainer 1 is choosing move in battle battle-gen1ou-249916 - first_turn? = True - opponent_first_turn? = True
move earthquake (Move object) in poke-env moved
move earthquake (Move object) in poke-env moved
RandomBaseline 1 is choosing move in battle battle-gen1ou-249916 - first_turn? = True - opponent_first_turn? = True

move earthquake (Move object) in poke-env moved
move earthquake (Move object) in poke-env moved
Gen1Trainer 1 is choosing move in battle battle-gen1ou-249916 - first_turn? = True - opponent_first_turn? = True
move blizzard (Move object) in poke-env moved
RandomBaseline 1 is choosing move in battle battle-gen1ou-249916 - first_turn? = True - opponent_first_turn? = True

move blizzard (Move object) in poke-env moved
Gen1Trainer 1 is choosing move in battle battle-gen1ou-249916 - first_turn? = True - opponent_first_turn? = True
move seismictoss (Move object) in poke-env moved
RandomBaseline 1 is choosing move in battle battle-gen1ou-249916 - first_turn? = True - opponent_first_turn? = True

move seismictoss (Move object) in poke-env moved
Gen1Trainer 1 is choosing move in battle battle-gen1ou-249916 - first_turn? = True - opponent_first_turn? = True
move seismictoss (Move object) in poke-env moved
RandomBaseline 1 is choosing move in battle battle-gen1ou-249916 - first_turn? = True - opponent_first_turn? = True
```
 

Seems like this can be fixed by simply setting `self._first_turn = False` in `Pokemon.moved`:

```
cubone switched OUT!
cubone switched in!
flareon switched in!
BugCatcher 1 is choosing move in battle battle-gen1ou-249924 - first_turn? = True - opponent_first_turn? = True

cubone switched in!
flareon switched OUT!
flareon switched in!
BugCatcher 2 is choosing move in battle battle-gen1ou-249924 - first_turn? = True - opponent_first_turn? = True

move fireblast (Move object) in poke-env moved
move seismictoss (Move object) in poke-env moved
BugCatcher 2 is choosing move in battle battle-gen1ou-249924 - first_turn? = False - opponent_first_turn? = False

move fireblast (Move object) in poke-env moved
move seismictoss (Move object) in poke-env moved
BugCatcher 1 is choosing move in battle battle-gen1ou-249924 - first_turn? = False - opponent_first_turn? = False
``` 

There is some weirdness going on b/c switches seem to be called twice at the start of the battle, and some move format messages are also called twice, but it doesn't look like this matters. 


Worried that the order of `choose_move` and `moved` calls would break in doubles battles. I don't have a great setup to test this but it seems to be ok:

Doubles Battle:

```
cloyster switched in!
kingler switched in!
stoutland switched OUT!
stoutland switched in!
dugtrioalola switched OUT!
dugtrioalola switched in!
BugCatcher 2 is choosing move in battle battle-gen8randomdoublesbattle-249948 - first_turn? = [True, True] - opponent_first_turn? = [True, True]

cloyster switched OUT!
cloyster switched in!
kingler switched OUT!
kingler switched in!
stoutland switched in!
dugtrioalola switched in!
BugCatcher 1 is choosing move in battle battle-gen8randomdoublesbattle-249948 - first_turn? = [True, True] - opponent_first_turn? = [True, True]

move protect (Move object) in poke-env moved
move highhorsepower (Move object) in poke-env moved
move facade (Move object) in poke-env moved
move superpower (Move object) in poke-env moved
BugCatcher 1 is choosing move in battle battle-gen8randomdoublesbattle-249948 - first_turn? = [False, False] - opponent_first_turn? = [False, False]
```